### PR TITLE
Return proper length and errors

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -7,6 +7,7 @@ extern int get_errno(void);
 
 */
 import "C"
+import "io"
 import "unsafe"
 import "syscall"
 import "github.com/shanemhansen/gossl/sslerr"


### PR DESCRIPTION
`io.Reader` and `io.Writer` are meant to return the number of bytes read or written. This implementation was returning the size of the input buffer, which would cause unexpected results when using buffered readers, etc.

This pull request resolves the issue with returning the value that was provided by the `SSL_read` and `SSL_write` methods.

This also resolves an issue with `C.SSL_ERROR_ZERO_RETURN` error codes, which indicate something similar to an `io.EOF`
