### PR TITLE
Fix an issue with using the NewConn for client connections

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -33,7 +33,7 @@ func (self *Listener) Accept() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	myconnection, err := NewConn(self.Context, c)
+	myconnection, err := NewServerConn(self.Context, c)
 	//ssl_err := myconnection.Handshake()
 	return myconnection, nil
 }

--- a/ssl.go
+++ b/ssl.go
@@ -28,11 +28,14 @@ func (self *SSL) SetBIO(readbio *BIO, writebio *BIO) {
 	C.SSL_set_bio(self.SSL,
 		(*C.BIO)(unsafe.Pointer(readbio.BIO)),
 		(*C.BIO)(unsafe.Pointer(writebio.BIO)))
-	C.SSL_set_accept_state(self.SSL)
 }
 func (self *SSL) SetAcceptState() {
 	C.SSL_set_accept_state(self.SSL)
 }
+func (self *SSL) SetConnectState() {
+	C.SSL_set_connect_state(self.SSL)
+}
+
 func (self *SSL) Shutdown() error {
 	//shutdown should happen in 2 steps
 	//see http://www.openssl.org/docs/ssl/SSL_shutdown.html


### PR DESCRIPTION
`C.SSL_set_connect_state` is required to initialize a client connection.

I'm up for any changes that should be made for the API, but calling `C.SSL_set_accept_state` by default prevents this library from being used for client connections.
