### PR TITLE
add http/tls skeleton pkgs

### DIFF
--- a/bio/bio.go
+++ b/bio/bio.go
@@ -1,51 +1,57 @@
-package gossl
+package bio
 
 /*
 #cgo pkg-config: openssl
-#include "openssl/err.h"
-#include "openssl/ssl.h"
-#include "openssl/bio.h"
-extern BIO_METHOD* BIO_s_conn(void);
-extern int go_conn_bio_write(BIO* bio, const char* buf, int num);
-extern int go_conn_bio_read(BIO* bio, char* buf, int num);
-extern int go_conn_bio_new(BIO* bio);
-extern int go_conn_bio_free(BIO* bio);
-extern long go_conn_bio_ctrl(BIO *b, int cmd, long num, void *ptr);
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
 
-static BIO_METHOD methods_connp={
- BIO_TYPE_SOURCE_SINK,
- "go net.Conn",
- go_conn_bio_write,
- go_conn_bio_read,
- NULL,
- NULL,
- go_conn_bio_ctrl,
- go_conn_bio_new,
- go_conn_bio_free
+extern BIO_METHOD *BIO_s_conn(void);
+extern int go_conn_bio_write(BIO *bio, const char *buf, int num);
+extern int go_conn_bio_read(BIO *bio, char *buf, int num);
+extern int go_conn_bio_new(BIO *bio);
+extern int go_conn_bio_free(BIO *bio);
+extern long go_conn_bio_ctrl(BIO *bio, int cmd, long num, void *ptr);
+
+static BIO_METHOD methods_connp = {
+	BIO_TYPE_SOURCE_SINK,
+	"go net.Conn",
+	go_conn_bio_write,
+	go_conn_bio_read,
+	NULL,
+	NULL,
+	go_conn_bio_ctrl,
+	go_conn_bio_new,
+	go_conn_bio_free
 };
-extern BIO_METHOD* BIO_s_conn(void) {
- return &methods_connp;
+
+extern BIO_METHOD *BIO_s_conn(void)
+{
+	return &methods_connp;
 }
-//lame wrapper around ssl's variadic put error
-void go_conn_put_error(const char* p) {
- ERR_add_error_data(1, p);
+
+void go_conn_put_error(const char *p)
+{
+	ERR_add_error_data(1, p);
 }
-void clear_sys_error(void) {
- errno = 0;
+
+void clear_sys_error(void)
+{
+	errno = 0;
 }
-void set_errno(int e) {
- errno = e;
+
+void set_errno(int e)
+{
+	errno = e;
 }
-int get_errno(void) {
- return errno;
+
+int get_errno(void)
+{
+	return errno;
 }
 */
 import "C"
 import "unsafe"
-
-import "fmt"
-
-var _ = fmt.Println
 
 type BIO struct {
 	BIO  *C.BIO
@@ -55,6 +61,7 @@ type BIO struct {
 func NewBIO(method *BIOMethod) *BIO {
 	return newBIO(C.BIO_new(method.BIOMethod))
 }
+
 func newBIO(bio *C.BIO) *BIO {
 	b := &BIO{BIO: bio}
 	return b
@@ -76,20 +83,23 @@ func (self *BIO) Write(b []byte) int {
 	ret := int(C.BIO_write(self.BIO, unsafe.Pointer(&b[0]), C.int(len(b))))
 	return ret
 }
+
 func (self *BIO) SetAppData(conn *Conn) {
 	self.BIO.ptr = unsafe.Pointer(conn)
 }
+
 func (self *BIO) GetAppData() *Conn {
 	return (*Conn)(self.BIO.ptr)
 }
+
 func (self *BIO) Ctrl(cmd int, larg int, data unsafe.Pointer) int {
 	return int(C.BIO_ctrl(self.BIO, C.int(cmd), C.long(larg), data))
 }
+
 func (self *BIO) GetBytes() []byte {
 	var temp *C.char
 	buf_len := self.Ctrl(int(C.BIO_CTRL_INFO), 0, unsafe.Pointer(&temp))
 	return C.GoBytes(unsafe.Pointer(temp), C.int(buf_len))
-
 }
 
 type BIOMethod struct {
@@ -99,9 +109,11 @@ type BIOMethod struct {
 func newBIOMethod(method *C.BIO_METHOD) *BIOMethod {
 	return &BIOMethod{method}
 }
+
 func BIOConn() *BIOMethod {
 	return newBIOMethod(C.BIO_s_conn())
 }
+
 func BIOSMem() *BIOMethod {
 	return newBIOMethod(C.BIO_s_mem())
 }

--- a/bio/bio_s_conn.go
+++ b/bio/bio_s_conn.go
@@ -1,21 +1,21 @@
-package gossl
+package bio
 
 /*
 #cgo pkg-config: openssl
-#include "openssl/ssl.h"
-#include "openssl/err.h"
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
 extern void go_conn_put_error(const char*);
 extern void set_errno(int);
 */
 import "C"
-import "io"
-import "unsafe"
-import "reflect"
-import "syscall"
-import "fmt"
-import "net"
-
-var _ = fmt.Println
+import (
+	"io"
+	"net"
+	"reflect"
+	"syscall"
+	"unsafe"
+)
 
 //export go_conn_bio_write
 func go_conn_bio_write(bio *C.BIO, buf *C.char, num C.int) C.int {
@@ -94,12 +94,7 @@ func go_conn_bio_ctrl(bio *C.BIO, cmd C.int, num C.long, ptr unsafe.Pointer) C.l
 	return C.long(1)
 }
 
-// Provides a zero copy interface for returning a go slice backed by a c array.
 func GoSliceFromCString(cArray *C.char, size int) (cslice []byte) {
-	//See http://code.google.com/p/go-wiki/wiki/cgo
-	//It turns out it's really easy to
-	//make a string from a *C.char and vise versa.
-	//not so easy to write to a c array.
 	sliceHeader := (*reflect.SliceHeader)((unsafe.Pointer(&cslice)))
 	sliceHeader.Cap = size
 	sliceHeader.Len = size

--- a/bio/bio_test.go
+++ b/bio/bio_test.go
@@ -1,7 +1,9 @@
-package gossl
+package bio
 
-import "testing"
-import "bytes"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestMemoryBIO(t *testing.T) {
 	bio := NewBIO(BIOSMem())

--- a/examples/testhttpserver/httpserver.go
+++ b/examples/testhttpserver/httpserver.go
@@ -15,7 +15,7 @@ func main() {
 		flag.PrintDefaults()
 		return
 	}
-	ctx := gossl.NewContext(gossl.SSLv3Method())
+	ctx := gossl.NewContext(gossl.TLSv1_2Method())
 	ctx.SetOptions(gossl.OP_NO_COMPRESSION)
 	err := ctx.UsePrivateKeyFile(*keypath, gossl.FILETYPE_PEM)
 	if err != nil {

--- a/http/transport.go
+++ b/http/transport.go
@@ -1,0 +1,257 @@
+package http
+
+/*
+#cgo pkg-config: openssl
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <openssl/ssl.h>
+
+struct ssl_connection_t {
+	int socket;
+	SSL *ssl_handle;
+	SSL_CTX *ssl_context;
+};
+
+typedef struct ssl_connection_t SSL_connection;
+
+static int tcp_connect(const char **address, const long *port)
+{
+	int handle, error;
+	struct hostent *host;
+	struct sockaddr_in server;
+
+	// TODO(runcom): replace with getaddrinfo(3)
+	host = gethostbyname(*address);
+	if (host == NULL)
+		return 0;
+
+	handle = socket(AF_INET, SOCK_STREAM, 0);
+	if (handle == -1)
+		return 0;
+
+	server.sin_family = AF_INET;
+	server.sin_port = htons(*port);
+	server.sin_addr = *((struct in_addr *)host->h_addr);
+	bzero(&(server.sin_zero), 8);
+
+	error = connect(handle, (struct sockaddr *)&server,
+	sizeof(struct sockaddr));
+	if (error == -1)
+		return 0;
+
+	return handle;
+}
+
+static SSL_connection *ssl_connect(const char *address, const long port)
+{
+	SSL_connection *conn;
+
+	conn = malloc(sizeof(SSL_connection));
+	if (conn == NULL)
+		return NULL;
+
+	conn->socket = tcp_connect(&address, &port);
+	if (conn->socket == 0)
+		goto out_bad;
+
+	SSL_load_error_strings();
+	SSL_library_init();
+
+	conn->ssl_context = SSL_CTX_new(SSLv23_client_method());
+	if (conn->ssl_context == NULL)
+		goto out_bad;
+
+	conn->ssl_handle = SSL_new(conn->ssl_context);
+	if (conn->ssl_handle == NULL)
+		goto out_bad;
+
+	if (!SSL_set_fd(conn->ssl_handle, conn->socket))
+		goto out_bad;
+
+	if (SSL_connect(conn->ssl_handle) != 1)
+		goto out_bad;
+
+	return conn;
+
+out_bad:
+	free(conn);
+	return NULL;
+}
+
+static int ssl_write(SSL_connection *conn, char *text)
+{
+	int res;
+
+	if (conn != NULL)
+		res = SSL_write(conn->ssl_handle, text, strlen(text));
+		if (res <= 0)
+			// The write operation was not successful. Probably the underlying
+			// connection was closed. Call SSL_get_error() with the return value
+			// ret to find out, whether an error occurred or the connection was
+			// shut down cleanly (SSL_ERROR_ZERO_RETURN).
+			// TODO(runcom): should differentiate for res == 0 as the man says
+			return res;
+		return 1;
+	return 0;
+}
+
+static char *ssl_read(SSL_connection *conn)
+{
+	const int read_size = 1024;
+	char *rc = NULL;
+	int received, count = 0;
+	char buffer[1024];
+
+	if (conn == NULL)
+		return NULL;
+
+	while (1) {
+		if (rc == NULL)
+			rc = malloc(read_size * sizeof(char) + 1);
+		else
+			rc = realloc(rc, (count + 1) * read_size * sizeof(char) + 1);
+
+		received = SSL_read(conn->ssl_handle, buffer, read_size);
+		if (received <= 0)
+			// an error or clean shutdown occurred...
+			break;
+
+		buffer[received] = '\0';
+
+		if (received > 0)
+			strcat(rc, buffer);
+
+		if (received < read_size)
+			break;
+
+		count++;
+	}
+
+	return rc;
+}
+
+static void ssl_disconnect(SSL_connection *conn)
+{
+	if (conn->socket)
+		close(conn->socket);
+
+	if (conn->ssl_handle) {
+		SSL_shutdown(conn->ssl_handle);
+		SSL_free(conn->ssl_handle);
+	}
+
+	if (conn->ssl_context)
+		SSL_CTX_free(conn->ssl_context);
+
+	free(conn);
+}
+
+static int c_strlen(char *buf)
+{
+	return strlen(buf);
+}
+*/
+import "C"
+import (
+	"errors"
+	"net/http"
+	"unsafe"
+)
+
+// The golang stdlib http.Client uses the http.DefaultTransport by defualt (and
+// subsequently http.Get(), etc).
+//
+// That DefaultTransport uses the stdlib crypto/tls.
+// To override usage of the stdlib crypto/tls, just set this OpenSSLRoundTripper
+// as the DefaultTransport for your application. Likely in an init() somewhere.
+//
+//   import "net/http"
+//
+//   func init() {
+//     http.DefaultTransport = &OpenSSLTransport{}
+//   }
+//
+type OpenSSLTransport struct {
+	// a default RoundTripper for all non-https schemes
+	// ( this defaults to http.DefaultTransport )
+	DefaultTransport http.RoundTripper
+}
+
+func (t *OpenSSLTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil {
+		req.Body.Close()
+		return nil, errors.New("http: nil Request.URL")
+	}
+	if req.Header == nil {
+		req.Body.Close()
+		return nil, errors.New("http: nil Request.Header")
+	}
+	// short circuit to most use-cases
+	if req.URL.Scheme != "https" {
+		if t.DefaultTransport != nil {
+			return t.DefaultTransport.RoundTrip(req)
+		}
+		return t.DefaultTransport.RoundTrip(req)
+	}
+	if req.URL.Host == "" {
+		req.Body.Close()
+		return nil, errors.New("http: no Host in request URL")
+	}
+
+	//treq := &transportRequest{Request: req}
+
+	conn, err := t.getConn(req)
+	if err != nil {
+		req.Body.Close()
+		return nil, err
+	}
+
+	_ = conn
+
+	//return pconn.roundTrip(treq)
+	return nil, nil
+}
+
+type transportRequest struct {
+	*http.Request // original request
+}
+
+type connection struct {
+	conn *C.SSL_connection
+}
+
+func (c *connection) Write(data []byte) error {
+	if C.ssl_write(c.conn, C.CString(string(data))) != 1 {
+		return errors.New("couldn't write to ssl connection")
+	}
+	return nil
+}
+
+func (c *connection) Read() ([]byte, error) {
+	read := C.ssl_read(c.conn)
+	if read == nil {
+		return nil, errors.New("error while reading from ssl connection")
+	}
+	return C.GoBytes(unsafe.Pointer(read), C.c_strlen(read)), nil
+}
+
+func (c *connection) Close() {
+	C.ssl_disconnect(c.conn)
+}
+
+func (t *OpenSSLTransport) getConn(req *http.Request) (*connection, error) {
+	addr := C.CString(req.URL.Host)
+	defer C.free(unsafe.Pointer(addr))
+	conn := C.ssl_connect(addr, 443)
+	if conn == nil {
+		return nil, errors.New("couldn't connect")
+	}
+	return &connection{conn: conn}, nil
+}

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+func TestRoundTripperWithoutURL(t *testing.T) {
+	tr := OpenSSLTransport{}
+	req, err := http.NewRequest("GET", "", bytes.NewBuffer(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.URL = nil
+	_, err = tr.RoundTrip(req)
+	expected := "http: nil Request.URL"
+	if err.Error() != expected {
+		t.Fatalf("Expected %q, got %q", expected, err.Error())
+	}
+}
+
+func TestGetConn(t *testing.T) {
+	tr := OpenSSLTransport{}
+	req, err := http.NewRequest("GET", "https://google.com", bytes.NewBuffer(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.getConn(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Close()
+}
+
+func TestGetConnFail(t *testing.T) {
+	tr := OpenSSLTransport{}
+	req, err := http.NewRequest("GET", "https://notfoundwtf.com", bytes.NewBuffer(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.getConn(req)
+	if err == nil {
+		c.Close()
+		t.Fatalf("Expected err, got nil instead")
+	}
+}
+
+func TestGetConnWriteRead(t *testing.T) {
+	tr := OpenSSLTransport{}
+	req, err := http.NewRequest("GET", "https://google.com", bytes.NewBuffer(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.getConn(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if err := c.Write(bytes.NewBufferString("GET /\r\n\r\n").Bytes()); err != nil {
+		t.Fatal(err)
+	}
+	b, err := c.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(b))
+}

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -1,0 +1,86 @@
+package net
+
+/*
+#cgo pkg-config: openssl
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+*/
+import "C"
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"time"
+)
+
+func Dial(network, address string, config *tls.config) (*Conn, error) {
+	switch network {
+	case "tcp":
+	default:
+		errors.New("unsupported network")
+	}
+	netConn, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	switch network {
+	case "tcp":
+		ctx := C.SSL_CTX_new(C.TLSv1_2_client_method())
+		if ctx == nil {
+			return nil, errors.New("problem creating ssl context")
+		}
+		ssl := C.SSL_new(ctx)
+		if ssl == nil {
+			return nil, errors.New("problem creating ssl")
+		}
+
+		break
+	//case "udp":
+	//context := C.SSL_CTX_new(C.DTLSv1_client_method())
+	//break
+	default:
+		return nil, errors.New("unsupported network")
+	}
+
+}
+
+type Conn struct {
+	bio  *C.BIO
+	ctx  *C.SSL_CTX
+	ssl  *C.SSL
+	conn net.Conn
+}
+
+func (c *Conn) Read(b []byte) (n int, err error) {
+
+}
+
+func (c *Conn) Write(b []byte) (n int, err error) {
+
+}
+
+func (c *Conn) Close() error {
+
+}
+
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+func (c *Conn) SetDeadline(t time.Time) error {
+
+}
+
+func (c *Conn) SetReadDeadline(t time.Time) error {
+
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+
+}


### PR DESCRIPTION
This PR adds two new pkgs: `http` and `tls`

`http` contains a basic POC of an `http.RoundTripper` implementation backed by OpenSSL. It's mean just as a poc because I plan to implement and abstract a new `SSLConn` which will implement Go's `net.Conn` interface by using an SSL `BIO` object which will include a `net.Conn` (for this I moved bio files to its own pkg)

`tls` is just a skeleton to guide me though the implementation and abstraction of all dependent objects (C.SSL_CTX, C.SSL, C.BIO etc etc) of a new `SSLConn` `net.Conn` implementation.

/cc @vbatts 

feedback always welcome