### PR TITLE
travis: test on latest of each go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-  - 1.8
-  - 1.7
-  - 1.6
+  - 1.x
+  - 1.8.x
+  - 1.7.x
+  - 1.6.x
 
 # maybe one day
 #  - go get github.com/golang/lint/golint


### PR DESCRIPTION
The "1.6" will only test that version, but not "1.6.1" and so on.
The ".x" is a indicator for the latest in a given release.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>